### PR TITLE
Allow the worker VPC and Lambda role to be configured when used as a module

### DIFF
--- a/deploy/aws/iam.tf
+++ b/deploy/aws/iam.tf
@@ -21,7 +21,8 @@ EOF
 }
 
 output "lambda_role_name" {
-  value = aws_iam_role.pullapprove_lambda_role.name
+  value       = aws_iam_role.pullapprove_lambda_role.name
+  description = "Additional IAM policies can be attached to this role if you're using PullApprove as a Terraform module (`module.<name>.lambda_role_name`)."
 }
 
 resource "aws_iam_policy" "pullapprove_logging_policy" {

--- a/deploy/aws/iam.tf
+++ b/deploy/aws/iam.tf
@@ -3,21 +3,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_iam_role" "pullapprove_lambda_role" {
   name = "pullapprove${var.aws_unique_suffix}"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  assume_role_policy = var.lambda_role_policy
 }
 
 resource "aws_iam_policy" "pullapprove_logging_policy" {

--- a/deploy/aws/iam.tf
+++ b/deploy/aws/iam.tf
@@ -3,7 +3,21 @@ data "aws_caller_identity" "current" {}
 resource "aws_iam_role" "pullapprove_lambda_role" {
   name = "pullapprove${var.aws_unique_suffix}"
 
-  assume_role_policy = var.lambda_role_policy
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
 }
 
 resource "aws_iam_policy" "pullapprove_logging_policy" {

--- a/deploy/aws/iam.tf
+++ b/deploy/aws/iam.tf
@@ -20,6 +20,10 @@ resource "aws_iam_role" "pullapprove_lambda_role" {
 EOF
 }
 
+output "lambda_role_name" {
+  value = aws_iam_role.pullapprove_lambda_role.name
+}
+
 resource "aws_iam_policy" "pullapprove_logging_policy" {
   name        = "pullapprove_logging${var.aws_unique_suffix}"
   path        = "/"

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -114,7 +114,10 @@ variable "worker_memory" {
 
 variable "worker_vpc_config" {
   default = {}
-  type    = object()
+  type = object({
+    security_group_ids = list(string),
+    subnet_ids         = list(string),
+  })
   description = "The vpc_config for the worker Lambda function (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config)"
 }
 

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -124,25 +124,6 @@ variable "worker_vpc_config" {
   description = "The vpc_config for the worker Lambda function (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config)"
 }
 
-variable "lambda_role_policy" {
-  default     = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-  description = "The IAM policy for the Lambda role (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#assume_role_policy)"
-}
-
 # Optional error tracking
 variable "sentry_dsn" {
   default     = ""

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -112,6 +112,12 @@ variable "worker_memory" {
   description = "Memory limit on pullapprove worker"
 }
 
+variable "worker_vpc_config" {
+  default = {}
+  type    = object()
+  description = "The vpc_config for the worker Lambda function (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config)"
+}
+
 # Optional error tracking
 variable "sentry_dsn" {
   default     = ""

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -113,10 +113,13 @@ variable "worker_memory" {
 }
 
 variable "worker_vpc_config" {
-  default = {}
+  default = {
+    security_group_ids = []
+    subnet_ids         = []
+  }
   type = object({
-    security_group_ids = list(string),
-    subnet_ids         = list(string),
+    subnet_ids         = list(string)
+    security_group_ids = list(string)
   })
   description = "The vpc_config for the worker Lambda function (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config)"
 }

--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -124,6 +124,25 @@ variable "worker_vpc_config" {
   description = "The vpc_config for the worker Lambda function (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#vpc_config)"
 }
 
+variable "lambda_role_policy" {
+  default     = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+  description = "The IAM policy for the Lambda role (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#assume_role_policy)"
+}
+
 # Optional error tracking
 variable "sentry_dsn" {
   default     = ""

--- a/deploy/aws/worker.tf
+++ b/deploy/aws/worker.tf
@@ -32,6 +32,8 @@ resource "aws_lambda_function" "pullapprove_worker" {
   }
 
   vpc_config {
+    # To set the worker VPC, either use these variables (useful if using pullapprove as a module)
+    # or manually replace these with references to additional Terraform resources in this repo
     subnet_ids         = var.worker_vpc_config.subnet_ids
     security_group_ids = var.worker_vpc_config.security_group_ids
   }

--- a/deploy/aws/worker.tf
+++ b/deploy/aws/worker.tf
@@ -7,7 +7,6 @@ resource "aws_lambda_function" "pullapprove_worker" {
   runtime          = "python3.8"
   timeout          = 300
   memory_size      = var.worker_memory
-  vpc_config       = var.worker_vpc_config
 
   environment {
     variables = {
@@ -30,6 +29,11 @@ resource "aws_lambda_function" "pullapprove_worker" {
       VERSION                = var.pullapprove_version
       REPORT_EXPIRATION_DAYS = var.report_expiration_days
     }
+  }
+
+  vpc_config {
+    subnet_ids         = var.worker_vpc_config.subnet_ids
+    security_group_ids = var.worker_vpc_config.security_group_ids
   }
 }
 

--- a/deploy/aws/worker.tf
+++ b/deploy/aws/worker.tf
@@ -7,6 +7,7 @@ resource "aws_lambda_function" "pullapprove_worker" {
   runtime          = "python3.8"
   timeout          = 300
   memory_size      = var.worker_memory
+  vpc_config       = var.worker_vpc_config
 
   environment {
     variables = {


### PR DESCRIPTION
When this repo is used as a Terraform module, you can now provide a VPC config:
```hcl
# Additional VPC resources defined outside of module
# ...

module "pullapprove_dev" {
  source = "git::https://github.com/dropseed/pullapprove-enterprise.git//deploy/aws?ref=worker-vpc"

  worker_vpc_config = {
    subnet_ids = [
      aws_subnet.pullapprove_subnet_private.id,
    ]
    security_group_ids = [
      aws_security_group.pullapprove_worker_security_group.id,
    ]
  }
  
  ...
}
```

And exporting the Lambda role name allows you to attach additional IAM policies from outside the module:
```hcl
resource "aws_iam_policy" "pullapprove_lambda_ip_policy" {
  name        = "pullapprove_lambda_ip${local.aws_unique_suffix}"
  path        = "/"
  description = "IAM policy for getting a static IP for the worker Lambda"

  policy = <<EOF
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "ec2:CreateNetworkInterface",
        "ec2:DescribeNetworkInterfaces",
        "ec2:DeleteNetworkInterface"
      ],
      "Effect": "Allow",
      "Resource": "*"
    }
  ]
}
EOF
}

resource "aws_iam_role_policy_attachment" "pullapprove_lambda_ip_attachment" {
  role       = module.pullapprove_dev.lambda_role_name
  policy_arn = aws_iam_policy.pullapprove_lambda_ip_policy.arn
}

module "pullapprove_dev" {
  source = "git::https://github.com/dropseed/pullapprove-enterprise.git//deploy/aws?ref=worker-vpc"

  ...
}
```